### PR TITLE
fix : LikeCount 내림차순 정렬 시점 수정

### DIFF
--- a/src/main/java/com/example/blog/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/blog/domain/post/controller/PostController.java
@@ -49,6 +49,7 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Operation(summary = "게시글 인기순 조회")
     @GetMapping("/posts/trending")
     public ResponseEntity<Page<PostResponseDTO>> getTrendingPosts(
             @RequestParam(value = "page", required = false, defaultValue = "1") int page

--- a/src/main/java/com/example/blog/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/post/service/PostServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.blog.domain.user.exception.UserNotFoundException;
 import com.example.blog.domain.user.repository.UserRepository;
 import com.example.blog.domain.user.service.S3Service;
 import com.example.blog.global.dto.StatusAndMessageDTO;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,9 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Service
 public class PostServiceImpl implements PostService {
+
+
+    private final EntityManager em;
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
@@ -88,10 +92,15 @@ public class PostServiceImpl implements PostService {
             // 게시글 좋아요 수
             post.setLikeCount(postLikeRepository.countByPostId(post.getId()));
 
+
             // 댓글 좋아요 수
             post.getComments().forEach(comment ->
                     comment.setLikeCount(commentLikeRepository.countByCommentId(comment.getId())));
+
+
         });
+
+
 
         return posts.map(PostResponseDTO::new);
     }
@@ -116,7 +125,11 @@ public class PostServiceImpl implements PostService {
             // 댓글 좋아요 수
             post.getComments().forEach(comment ->
                     comment.setLikeCount(commentLikeRepository.countByCommentId(comment.getId())));
+
+            em.flush();
         });
+
+        posts = postRepository.findAll(pageable);
 
         return posts.map(PostResponseDTO::new);
     }


### PR DESCRIPTION
좋아요 숫자가 트랜잭션 이후에 반영되어 첫 번째 응답시 정렬되지 않은 결과를 return하는 문제가 발생함. 따라서 flush 한 다음 다시 페이지를 로드하여 리턴하도록 변경함. (임시방편)